### PR TITLE
feat: add php 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         php-version:
           - '7.4'
           - '8.0'
+          - '8.1'
 
     steps:
       - name: Checkout

--- a/composer.lock
+++ b/composer.lock
@@ -2520,16 +2520,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.14",
+            "version": "v5.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "984ea2c0f45f42dfed01d2f3987b187467c4b16d"
+                "reference": "ea59bb0edfaf9f28d18d8791410ee0355f317669"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/984ea2c0f45f42dfed01d2f3987b187467c4b16d",
-                "reference": "984ea2c0f45f42dfed01d2f3987b187467c4b16d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ea59bb0edfaf9f28d18d8791410ee0355f317669",
+                "reference": "ea59bb0edfaf9f28d18d8791410ee0355f317669",
                 "shasum": ""
             },
             "require": {
@@ -2599,7 +2599,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.14"
+                "source": "https://github.com/symfony/console/tree/v5.4.15"
             },
             "funding": [
                 {
@@ -2615,7 +2615,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-07T08:01:20+00:00"
+            "time": "2022-10-26T21:41:52+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3824,16 +3824,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.14",
+            "version": "v5.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "089e7237497fae7a9c404d0c3aeb8db3254733e4"
+                "reference": "571334ce9f687e3e6af72db4d3b2a9431e4fd9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/089e7237497fae7a9c404d0c3aeb8db3254733e4",
-                "reference": "089e7237497fae7a9c404d0c3aeb8db3254733e4",
+                "url": "https://api.github.com/repos/symfony/string/zipball/571334ce9f687e3e6af72db4d3b2a9431e4fd9ed",
+                "reference": "571334ce9f687e3e6af72db4d3b2a9431e4fd9ed",
                 "shasum": ""
             },
             "require": {
@@ -3890,7 +3890,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.14"
+                "source": "https://github.com/symfony/string/tree/v5.4.15"
             },
             "funding": [
                 {
@@ -3971,5 +3971,5 @@
         "ext-mbstring": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" stderr="true">
   <coverage>
     <include>
       <directory>src/</directory>

--- a/src/Database.php
+++ b/src/Database.php
@@ -163,6 +163,7 @@ class Database implements SessionHandlerInterface, SessionUpdateTimestampHandler
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function gc($max_lifetime): bool
     {
         try {

--- a/src/File.php
+++ b/src/File.php
@@ -124,6 +124,7 @@ class File implements SessionHandlerInterface, SessionUpdateTimestampHandlerInte
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function gc($max_lifetime): bool
     {
         $pattern = $this->savePath . \DIRECTORY_SEPARATOR . $this->prefix . '*';

--- a/src/Redis.php
+++ b/src/Redis.php
@@ -122,6 +122,7 @@ class Redis implements SessionHandlerInterface, SessionUpdateTimestampHandlerInt
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function gc($max_lifetime): bool
     {
         return true;

--- a/tests/DefaultEncryptionTest.php
+++ b/tests/DefaultEncryptionTest.php
@@ -49,6 +49,7 @@ class DefaultEncryptionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */

--- a/tests/DefaultEncryptionTest.php
+++ b/tests/DefaultEncryptionTest.php
@@ -11,8 +11,6 @@ use Rancoud\Session\Session;
 
 /**
  * Class DefaultEncryptionTest.
- *
- * @runTestsInSeparateProcesses
  */
 class DefaultEncryptionTest extends TestCase
 {
@@ -50,9 +48,6 @@ class DefaultEncryptionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testReadAndWrite(): void

--- a/tests/DefaultEncryptionTest.php
+++ b/tests/DefaultEncryptionTest.php
@@ -11,6 +11,8 @@ use Rancoud\Session\Session;
 
 /**
  * Class DefaultEncryptionTest.
+ *
+ * @runTestsInSeparateProcesses
  */
 class DefaultEncryptionTest extends TestCase
 {

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -33,6 +33,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -44,6 +45,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -56,6 +58,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -72,6 +75,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -91,6 +95,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -109,6 +114,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -125,6 +131,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -140,6 +147,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -155,6 +163,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -170,6 +179,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -185,6 +195,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -198,6 +209,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -211,6 +223,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -224,6 +237,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -251,6 +265,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -264,6 +279,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -288,6 +304,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -312,6 +329,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Rancoud\Database\DatabaseException
      * @throws \Exception
@@ -338,6 +356,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Rancoud\Database\DatabaseException
      * @throws \Exception
@@ -372,6 +391,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -394,6 +414,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -416,6 +437,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -439,6 +461,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -462,6 +485,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -475,6 +499,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -488,6 +513,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws SessionException
      * @throws \Exception
@@ -510,6 +536,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testSetOptionThrowException(): void
     {
@@ -521,6 +548,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -537,6 +565,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -602,6 +631,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -619,6 +649,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -637,6 +668,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -651,6 +683,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -666,6 +699,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Exception
      */
@@ -678,6 +712,7 @@ class SessionTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      *
      * @throws \Rancoud\Database\DatabaseException
      * @throws \Exception

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -18,10 +18,6 @@ class SessionTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (Session::hasStarted()) {
-            Session::destroy();
-        }
-
         $path = \ini_get('session.save_path');
         if (empty($path)) {
             $path = \DIRECTORY_SEPARATOR . 'tmp';
@@ -120,6 +116,8 @@ class SessionTest extends TestCase
      */
     public function testStartException(): void
     {
+        @session_destroy();
+
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Session already started');
 
@@ -133,6 +131,8 @@ class SessionTest extends TestCase
      */
     public function testUseDefaultDriverWhenAlreadyStartedException(): void
     {
+        @session_destroy();
+
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Session already started');
 
@@ -146,6 +146,8 @@ class SessionTest extends TestCase
      */
     public function testUseFileDriverWhenAlreadyStartedException(): void
     {
+        @session_destroy();
+
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Session already started');
 
@@ -159,6 +161,8 @@ class SessionTest extends TestCase
      */
     public function testUseCustomDriverWhenAlreadyStartedException(): void
     {
+        @session_destroy();
+
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Session already started');
 
@@ -172,6 +176,8 @@ class SessionTest extends TestCase
      */
     public function testUseDefaultDriver(): void
     {
+        @session_destroy();
+
         Session::useDefaultDriver();
         Session::start();
 
@@ -183,6 +189,8 @@ class SessionTest extends TestCase
      */
     public function testUseDefaultEncryptionDriver(): void
     {
+        @session_destroy();
+
         Session::useDefaultEncryptionDriver('randomKey');
         Session::start();
 
@@ -194,6 +202,8 @@ class SessionTest extends TestCase
      */
     public function testUseFileDriver(): void
     {
+        @session_destroy();
+
         Session::useFileDriver();
         Session::start();
 
@@ -205,6 +215,8 @@ class SessionTest extends TestCase
      */
     public function testUseFileDriverWithPrefix(): void
     {
+        @session_destroy();
+
         $prefix = 'youhou_';
         Session::useFileDriver();
         Session::setPrefixForFile($prefix);

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -13,6 +13,8 @@ use Rancoud\Session\SessionException;
 
 /**
  * Class SessionTest.
+ *
+ * @runTestsInSeparateProcesses
  */
 class SessionTest extends TestCase
 {

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Rancoud\Session\File;
 use Rancoud\Session\Session;
 use Rancoud\Session\SessionException;
+use ReflectionClass;
 
 /**
  * Class SessionTest.
@@ -18,6 +19,11 @@ class SessionTest extends TestCase
 {
     protected function setUp(): void
     {
+        $class = new ReflectionClass(Session::class);
+        $prop = $class->getProperty('hasStarted');
+        $prop->setAccessible(true);
+        $prop->setValue(false);
+
         $path = \ini_get('session.save_path');
         if (empty($path)) {
             $path = \DIRECTORY_SEPARATOR . 'tmp';
@@ -116,8 +122,6 @@ class SessionTest extends TestCase
      */
     public function testStartException(): void
     {
-        @session_destroy();
-
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Session already started');
 
@@ -131,8 +135,6 @@ class SessionTest extends TestCase
      */
     public function testUseDefaultDriverWhenAlreadyStartedException(): void
     {
-        @session_destroy();
-
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Session already started');
 
@@ -146,8 +148,6 @@ class SessionTest extends TestCase
      */
     public function testUseFileDriverWhenAlreadyStartedException(): void
     {
-        @session_destroy();
-
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Session already started');
 
@@ -161,8 +161,6 @@ class SessionTest extends TestCase
      */
     public function testUseCustomDriverWhenAlreadyStartedException(): void
     {
-        @session_destroy();
-
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Session already started');
 
@@ -176,8 +174,6 @@ class SessionTest extends TestCase
      */
     public function testUseDefaultDriver(): void
     {
-        @session_destroy();
-
         Session::useDefaultDriver();
         Session::start();
 
@@ -189,8 +185,6 @@ class SessionTest extends TestCase
      */
     public function testUseDefaultEncryptionDriver(): void
     {
-        @session_destroy();
-
         Session::useDefaultEncryptionDriver('randomKey');
         Session::start();
 
@@ -202,8 +196,6 @@ class SessionTest extends TestCase
      */
     public function testUseFileDriver(): void
     {
-        @session_destroy();
-
         Session::useFileDriver();
         Session::start();
 
@@ -215,8 +207,6 @@ class SessionTest extends TestCase
      */
     public function testUseFileDriverWithPrefix(): void
     {
-        @session_destroy();
-
         $prefix = 'youhou_';
         Session::useFileDriver();
         Session::setPrefixForFile($prefix);

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -34,9 +34,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testGetNull(): void
@@ -46,9 +43,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testSet(): void
@@ -59,9 +53,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testHas(): void
@@ -76,9 +67,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testHasKeyAndValue(): void
@@ -96,9 +84,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testRemove(): void
@@ -115,9 +100,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testGetAndRemove(): void
@@ -132,9 +114,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testStartException(): void
@@ -148,9 +127,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseDefaultDriverWhenAlreadyStartedException(): void
@@ -164,9 +140,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseFileDriverWhenAlreadyStartedException(): void
@@ -180,9 +153,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseCustomDriverWhenAlreadyStartedException(): void
@@ -196,9 +166,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseDefaultDriver(): void
@@ -210,9 +177,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseDefaultEncryptionDriver(): void
@@ -224,9 +188,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseFileDriver(): void
@@ -238,9 +199,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseFileDriverWithPrefix(): void
@@ -266,9 +224,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseFileEncryptionDriver(): void
@@ -280,9 +235,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseNewDatabaseDriver(): void
@@ -305,9 +257,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseNewDatabaseEncryptionDriver(): void
@@ -330,9 +279,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Rancoud\Database\DatabaseException
      * @throws \Exception
      */
@@ -357,9 +303,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Rancoud\Database\DatabaseException
      * @throws \Exception
      */
@@ -392,9 +335,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseNewRedisDriver(): void
@@ -415,9 +355,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseNewRedisEncryptionDriver(): void
@@ -438,9 +375,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseCurrentRedisDriver(): void
@@ -462,9 +396,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseCurrentRedisEncryptionDriver(): void
@@ -486,9 +417,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseCustomDriver(): void
@@ -500,9 +428,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUseEncryptionDriverThrowExceptionWhenMethodIncrorrect(): void
@@ -514,9 +439,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws SessionException
      * @throws \Exception
      */
@@ -536,10 +458,7 @@ class SessionTest extends TestCase
         static::assertSame('my_other_name', $customOption);
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    /**/
     public function testSetOptionThrowException(): void
     {
         $this->expectException(SessionException::class);
@@ -549,9 +468,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testGetAll(): void
@@ -566,9 +482,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testFlash(): void
@@ -632,9 +545,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testRollback(): void
@@ -650,9 +560,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testUnsaved(): void
@@ -669,9 +576,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testRegenerate(): void
@@ -684,9 +588,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testDestroy(): void
@@ -700,9 +601,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Exception
      */
     public function testSetReadOnly(): void
@@ -713,9 +611,6 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     *
      * @throws \Rancoud\Database\DatabaseException
      * @throws \Exception
      */

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -13,8 +13,6 @@ use Rancoud\Session\SessionException;
 
 /**
  * Class SessionTest.
- *
- * @runTestsInSeparateProcesses
  */
 class SessionTest extends TestCase
 {

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -18,6 +18,10 @@ class SessionTest extends TestCase
 {
     protected function setUp(): void
     {
+        if (Session::hasStarted()) {
+            Session::destroy();
+        }
+
         $path = \ini_get('session.save_path');
         if (empty($path)) {
             $path = \DIRECTORY_SEPARATOR . 'tmp';

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -63,9 +63,9 @@ class SessionTest extends TestCase
      */
     public function testHas(): void
     {
-        Session::set('a', 'b');
+        Session::set('c', 'd');
 
-        $value = Session::has('a');
+        $value = Session::has('c');
         static::assertTrue($value);
 
         $value = Session::has('empty');
@@ -77,15 +77,15 @@ class SessionTest extends TestCase
      */
     public function testHasKeyAndValue(): void
     {
-        Session::set('a', 'b');
+        Session::set('e', 'f');
 
-        $value = Session::hasKeyAndValue('a', 'b');
+        $value = Session::hasKeyAndValue('e', 'f');
         static::assertTrue($value);
 
         $value = Session::has('empty');
         static::assertFalse($value);
 
-        $value = Session::hasKeyAndValue('a', 'empty');
+        $value = Session::hasKeyAndValue('e', 'empty');
         static::assertFalse($value);
     }
 
@@ -94,10 +94,10 @@ class SessionTest extends TestCase
      */
     public function testRemove(): void
     {
-        Session::set('a', 'b');
+        Session::set('g', 'h');
 
-        Session::remove('a');
-        $value = Session::get('a');
+        Session::remove('g');
+        $value = Session::get('g');
         static::assertNull($value);
 
         Session::remove('empty');
@@ -110,10 +110,10 @@ class SessionTest extends TestCase
      */
     public function testGetAndRemove(): void
     {
-        Session::set('a', 'b');
+        Session::set('i', 'j');
 
-        $value = Session::getAndRemove('a');
-        static::assertSame('b', $value);
+        $value = Session::getAndRemove('i');
+        static::assertSame('j', $value);
 
         $value = Session::getAndRemove('empty');
         static::assertNull($value);

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -22,9 +22,27 @@ class SessionTest extends TestCase
         @session_destroy();
 
         $class = new ReflectionClass(Session::class);
-        $prop = $class->getProperty('hasStarted');
-        $prop->setAccessible(true);
-        $prop->setValue(false);
+        $propHasStarted = $class->getProperty('hasStarted');
+        $propHasStarted->setAccessible(true);
+        $propHasStarted->setValue(false);
+
+        $propDriver = $class->getProperty('driver');
+        $propDriver->setAccessible(true);
+        $propDriver->setValue(null);
+
+        $propHasChanged = $class->getProperty('hasChanged');
+        $propHasChanged->setAccessible(true);
+        $propHasChanged->setValue(true);
+
+        $propOptions = $class->getProperty('options');
+        $propOptions->setAccessible(true);
+        $propOptions->setValue([
+            'read_and_close'   => true,
+            'cookie_httponly'  => '1',
+            'use_only_cookies' => '1',
+            'use_trans_sid'    => '0',
+            'use_strict_mode'  => '1'
+        ]);
 
         $path = \ini_get('session.save_path');
         if (empty($path)) {

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -19,6 +19,8 @@ class SessionTest extends TestCase
 {
     protected function setUp(): void
     {
+        @session_destroy();
+
         $class = new ReflectionClass(Session::class);
         $prop = $class->getProperty('hasStarted');
         $prop->setAccessible(true);


### PR DESCRIPTION
## Description
> Add PHP 8.1 in tests

## Changelist
- update github action `test.yml`
- composer update
- remove tests with `@runInSeparateProcess`, it causes error in `serialize()` with phpunit (only in PHP 8.1)
- add a reset for each test in SessionTest to replace the `@runInSeparateProcess`