### PR TITLE
fix(coverage): use lcov.info instead of clover.xml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
         uses: codecov/codecov-action@v3
         if: success()
         with:
-          file: ./coverage/clover.xml
+          file: ./coverage/lcov.info


### PR DESCRIPTION
## Description
`Codecov.io` didn't have the same level of coverage when uploading different file from same tests.
Use `lcov.info` instead of `clover.xml`

## Changelist
- Update `.github/workflows/tests.yml`