### PR TITLE
chore: update tests for phpunit 10 and 11

### DIFF
--- a/tests/DatabaseEncryptionTest.php
+++ b/tests/DatabaseEncryptionTest.php
@@ -105,7 +105,9 @@ class DatabaseEncryptionTest extends TestCase
         static::assertNotEmpty($row);
         static::assertNotSame($data, $row['content']);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInDatabaseDecrypted = $encryptionTrait->decrypt($row['content']);
         static::assertSame($data, $dataInDatabaseDecrypted);
@@ -339,7 +341,9 @@ class DatabaseEncryptionTest extends TestCase
         static::assertNotEmpty($row1);
         static::assertNotSame($data, $row1['content']);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInDatabaseDecrypted = $encryptionTrait->decrypt($row1['content']);
         static::assertSame($data, $dataInDatabaseDecrypted);
@@ -352,7 +356,9 @@ class DatabaseEncryptionTest extends TestCase
 
         static::assertNotEmpty($row2);
         static::assertNotSame($data, $row2['content']);
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInDatabaseDecrypted = $encryptionTrait->decrypt($row2['content']);
         static::assertSame($data, $dataInDatabaseDecrypted);

--- a/tests/DefaultEncryptionTest.php
+++ b/tests/DefaultEncryptionTest.php
@@ -58,7 +58,9 @@ class DefaultEncryptionTest extends TestCase
         $data = $this->foundSessionFile();
         static::assertNotFalse($data);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataDecrypted = $encryptionTrait->decrypt($data);
         static::assertSame('a|s:1:"b";', $dataDecrypted);

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -14,7 +14,9 @@ class EncryptionTest extends TestCase
 {
     public function testDefaultEncryption(): void
     {
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
 
         $dataToEncrypt = 'this is something to encrypt';
 
@@ -29,7 +31,9 @@ class EncryptionTest extends TestCase
     {
         $failedMethods = [];
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
 
         $dataToEncrypt = 'this is something to encrypt';
 
@@ -58,7 +62,9 @@ class EncryptionTest extends TestCase
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Unknown method: method');
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setMethod('method');
     }
 
@@ -154,7 +160,9 @@ class EncryptionTest extends TestCase
         $this->expectException(SessionException::class);
         $this->expectExceptionMessage('Key has to be a non-empty string');
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $dataToEncrypt = 'this is something to encrypt';
         $encryptionTrait->encrypt($dataToEncrypt);
     }

--- a/tests/FileEncryptionTest.php
+++ b/tests/FileEncryptionTest.php
@@ -99,7 +99,9 @@ class FileEncryptionTest extends TestCase
         $dataInFile = \file_get_contents($this->getPath() . \DIRECTORY_SEPARATOR . 'sess_' . $sessionId);
         static::assertNotSame($data, $dataInFile);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInFileDecrypted = $encryptionTrait->decrypt($dataInFile);
         static::assertSame($data, $dataInFileDecrypted);
@@ -224,7 +226,9 @@ class FileEncryptionTest extends TestCase
         $oldFileModifiedTime = \filemtime($this->getPath() . \DIRECTORY_SEPARATOR . 'sess_' . $sessionId);
         static::assertNotSame($data, $dataInFile);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInFileDecrypted = $encryptionTrait->decrypt($dataInFile);
         static::assertSame($data, $dataInFileDecrypted);
@@ -238,7 +242,9 @@ class FileEncryptionTest extends TestCase
         $dataInFile2 = \file_get_contents($this->getPath() . \DIRECTORY_SEPARATOR . 'sess_' . $sessionId);
         static::assertNotSame($data, $dataInFile2);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInFileDecrypted = $encryptionTrait->decrypt($dataInFile2);
         static::assertSame($data, $dataInFileDecrypted);

--- a/tests/RedisEncryptionTest.php
+++ b/tests/RedisEncryptionTest.php
@@ -76,7 +76,9 @@ class RedisEncryptionTest extends TestCase
         $dataInRedis = static::$redis->get($sessionId);
         static::assertNotSame($data, $dataInRedis);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInRedisDecrypted = $encryptionTrait->decrypt($dataInRedis);
         static::assertSame($data, $dataInRedisDecrypted);
@@ -230,7 +232,9 @@ class RedisEncryptionTest extends TestCase
         static::assertNotSame($data, $dataInRedis);
         $ttl1 = static::$redis->ttl($sessionId);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInRedisDecrypted = $encryptionTrait->decrypt($dataInRedis);
         static::assertSame($data, $dataInRedisDecrypted);
@@ -246,7 +250,9 @@ class RedisEncryptionTest extends TestCase
         static::assertNotSame($data, $dataInRedis2);
         $ttl3 = static::$redis->ttl($sessionId);
 
-        $encryptionTrait = $this->getObjectForTrait('Rancoud\Session\Encryption');
+        $encryptionTrait = new class {
+            use \Rancoud\Session\Encryption;
+        };
         $encryptionTrait->setKey('randomKey');
         $dataInRedisDecrypted = $encryptionTrait->decrypt($dataInRedis2);
         static::assertSame($data, $dataInRedisDecrypted);


### PR DESCRIPTION
# Description
Update tests to avoid deprecations and failed tests by removing `getObjectForTrait`.