### PR TITLE
feat: add Session::deleteUserSessionsInDatabase and Session::deleteAnonymousSessionsInDatabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ When flash data is restore, it will be delete in $_SESSION.
 * setUserIdForDatabase(userId: int): void
 * setLengthSessionID(length: int): void
 * getLengthSessionID(): int
-* deleteUserSessions(int $userID): void
-* deleteAnonymousSessions(): int
+* deleteUserSessionsInDatabase(int $userID): void
+* deleteAnonymousSessionsInDatabase(): int
 
 #### Static Redis Driver
 * useNewRedisDriver(configuration: array|string): void

--- a/src/DriverManager.php
+++ b/src/DriverManager.php
@@ -198,4 +198,18 @@ abstract class DriverManager
             static::$driver->setPrefix($prefix);
         }
     }
+
+    public static function deleteUserSessionsInDatabase(int $userID): void
+    {
+        if (\method_exists(static::$driver, 'deleteUserSessions')) {
+            static::$driver->deleteUserSessions($userID);
+        }
+    }
+
+    public static function deleteAnonymousSessionsInDatabase(): void
+    {
+        if (\method_exists(static::$driver, 'deleteAnonymousSessions')) {
+            static::$driver->deleteAnonymousSessions();
+        }
+    }
 }

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -153,7 +153,7 @@ trait Encryption
 
         /** @noinspection CryptographicallySecureRandomnessInspection */
         $iv = \openssl_random_pseudo_bytes($length, $cstrong);
-        /** @noinspection PhpStrictComparisonWithOperandsOfDifferentTypesInspection */
+        /* @noinspection PhpStrictComparisonWithOperandsOfDifferentTypesInspection */
         if ($iv === false || $cstrong === false) {
             // @codeCoverageIgnoreStart
             // Could not reach this statement without mocking the function

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -153,7 +153,7 @@ trait Encryption
 
         /** @noinspection CryptographicallySecureRandomnessInspection */
         $iv = \openssl_random_pseudo_bytes($length, $cstrong);
-        /* @noinspection PhpStrictComparisonWithOperandsOfDifferentTypesInspection */
+        /** @noinspection PhpStrictComparisonWithOperandsOfDifferentTypesInspection */
         if ($iv === false || $cstrong === false) {
             // @codeCoverageIgnoreStart
             // Could not reach this statement without mocking the function

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -308,8 +308,24 @@ class SessionTest extends TestCase
         $sessionId = Session::getId();
         Session::commit();
 
+        $sql = 'REPLACE INTO sessions VALUES(:id, null, UTC_TIMESTAMP(), :content)';
+        $params = ['id' => 'session_123', 'content' => 'content'];
+        $db->insert($sql, $params);
+
+        static::assertSame(1, $db->count('SELECT COUNT(id) FROM sessions WHERE id_user IS NULL'));
+        static::assertSame(1, $db->count('SELECT COUNT(id) FROM sessions WHERE id_user IS NOT NULL'));
+
         $userIdInTable = (int) $db->selectVar('SELECT id_user FROM sessions WHERE id = :id', ['id' => $sessionId]);
         static::assertSame($userId, $userIdInTable);
+
+        Session::deleteAnonymousSessionsInDatabase();
+
+        static::assertEmpty($db->count('SELECT COUNT(id) FROM sessions WHERE id_user IS NULL'));
+        static::assertSame(1, $db->count('SELECT COUNT(id) FROM sessions WHERE id_user IS NOT NULL'));
+
+        Session::deleteUserSessionsInDatabase($userId);
+
+        static::assertEmpty($db->count('SELECT COUNT(id) FROM sessions WHERE id = :id', ['id' => $sessionId]));
     }
 
     /** @throws \Exception */


### PR DESCRIPTION
# Description
* add `Session::deleteUserSessionsInDatabase()` for removing all sessions attached to a specific user.
* add `Session::deleteAnonymousSessionsInDatabase()` for removing all sessions not attached to a user.